### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/tests/LitJWT.Tests/LitJWT.Tests.csproj
+++ b/tests/LitJWT.Tests/LitJWT.Tests.csproj
@@ -10,11 +10,11 @@
 
     <ItemGroup>
         <PackageReference Include="RandomFixtureKit" Version="1.0.0" />
-        <PackageReference Include="FluentAssertions" Version="5.6.0" />
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+        <PackageReference Include="FluentAssertions" Version="5.8.0" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.6.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
Hi@guitarrapc, I found an issue in the LitJWT.Tests.csproj:

Packages FluentAssertions v5.6.0, System.IdentityModel.Tokens.Jwt v5.4.0, Microsoft.NET.Test.Sdk v16.0.1 and xunit.runner.visualstudio v2.4.1 transitively introduce 108 dependencies into LitJWT’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/LitJWT.html)), while FluentAssertions v5.8.0, System.IdentityModel.Tokens.Jwt v5.6.0, Microsoft.NET.Test.Sdk v16.1.0 and xunit.runner.visualstudio v2.4.2 can only introduce 79 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/LitJWT_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose