### PR TITLE
Flexibilice token lifetime validation

### DIFF
--- a/src/LitJWT/JwtDecoder.cs
+++ b/src/LitJWT/JwtDecoder.cs
@@ -171,28 +171,24 @@ namespace LitJWT
             }
         }
 
-        public DecodeResult TryDecode<T>(ReadOnlySpan<byte> utf8token, out T payloadResult)
-        {
-            return TryDecodeCore(utf8token, InternalPayloadParser<T>, null, out payloadResult);
-        }
-
-        public DecodeResult TryDecode<T>(
-            ReadOnlySpan<byte> utf8token,
-            TokenValidationParameters<T> validationParameters,
-            out T payloadResult)
-        {
-            if (validationParameters == null)
-                throw new ArgumentNullException(nameof(validationParameters));
-
-            return TryDecodeCore(
-                utf8token, InternalPayloadParser<T>, validationParameters, out payloadResult);
-        }
-
+        #region "(token, out payloadResult) overloads"
         public DecodeResult TryDecode<T>(string token, out T payloadResult)
         {
             return TryDecodeCore(token.AsSpan(), InternalPayloadParser<T>, null, out payloadResult);
         }
 
+        public DecodeResult TryDecode<T>(ReadOnlySpan<char> token, out T payloadResult)
+        {
+            return TryDecodeCore(token, InternalPayloadParser<T>, null, out payloadResult);
+        }
+
+        public DecodeResult TryDecode<T>(ReadOnlySpan<byte> utf8token, out T payloadResult)
+        {
+            return TryDecodeCore(utf8token, InternalPayloadParser<T>, null, out payloadResult);
+        }
+        #endregion
+
+        #region "(token, validationParameters, payloadResult) overloads"
         public DecodeResult TryDecode<T>(
             string token, TokenValidationParameters<T> validationParameters, out T payloadResult)
         {
@@ -202,12 +198,7 @@ namespace LitJWT
             return TryDecodeCore(
                 token.AsSpan(), InternalPayloadParser<T>, null, out payloadResult);
         }
-
-        public DecodeResult TryDecode<T>(ReadOnlySpan<char> token, out T payloadResult)
-        {
-            return TryDecodeCore(token, InternalPayloadParser<T>, null, out payloadResult);
-        }
-
+        
         public DecodeResult TryDecode<T>(
             ReadOnlySpan<char> token,
             TokenValidationParameters<T> validationParameters,
@@ -222,12 +213,62 @@ namespace LitJWT
 
         public DecodeResult TryDecode<T>(
             ReadOnlySpan<byte> utf8token,
+            TokenValidationParameters<T> validationParameters,
+            out T payloadResult)
+        {
+            if (validationParameters == null)
+                throw new ArgumentNullException(nameof(validationParameters));
+
+            return TryDecodeCore(
+                utf8token, InternalPayloadParser<T>, validationParameters, out payloadResult);
+        }
+        #endregion
+
+        #region "(token, payloadParser, payloadResult) overloads"
+        public DecodeResult TryDecode<T>(
+            string token, PayloadParser<T> payloadParser, out T payloadResult)
+        {
+            return TryDecode(token.AsSpan(), payloadParser, out payloadResult);
+        }
+
+        public DecodeResult TryDecode<T>(
+            ReadOnlySpan<char> token, PayloadParser<T> payloadParser, out T payloadResult)
+        {
+            return TryDecodeCore(token, payloadParser, null, out payloadResult);
+        }
+
+        public DecodeResult TryDecode<T>(
+            ReadOnlySpan<byte> utf8token,
             PayloadParser<T> payloadParser,
             out T payloadResult)
         {
             return TryDecodeCore(utf8token, payloadParser, null, out payloadResult);
         }
+        #endregion
 
+        #region "(token, payloadParser, validationParameters, payloadResult) overloads"
+        public DecodeResult TryDecode<T>(
+            string token,
+            PayloadParser<T> payloadParser,
+            TokenValidationParameters<T> validationParameters,
+            out T payloadResult)
+        {
+            return TryDecodeCore(
+                token.AsSpan(), payloadParser, validationParameters, out payloadResult);
+        }
+        
+        public DecodeResult TryDecode<T>(
+            ReadOnlySpan<char> token,
+            PayloadParser<T> payloadParser,
+            TokenValidationParameters<T> validationParameters,
+            out T payloadResult)
+        {
+            if (validationParameters == null)
+                throw new ArgumentNullException(nameof(validationParameters));
+
+            return TryDecodeCore(token, payloadParser, validationParameters, out payloadResult);
+        }
+        
         public DecodeResult TryDecode<T>(
             ReadOnlySpan<byte> utf8token,
             PayloadParser<T> payloadParser,
@@ -240,40 +281,7 @@ namespace LitJWT
             return TryDecodeCore(
                 utf8token, payloadParser, validationParameters, out payloadResult);
         }
-
-        public DecodeResult TryDecode<T>(
-            string token, PayloadParser<T> payloadParser, out T payloadResult)
-        {
-            return TryDecode(token.AsSpan(), payloadParser, out payloadResult);
-        }
-
-        public DecodeResult TryDecode<T>(
-            string token,
-            PayloadParser<T> payloadParser,
-            TokenValidationParameters<T> validationParameters,
-            out T payloadResult)
-        {
-            return TryDecodeCore(
-                token.AsSpan(), payloadParser, validationParameters, out payloadResult);
-        }
-
-        public DecodeResult TryDecode<T>(
-            ReadOnlySpan<char> token, PayloadParser<T> payloadParser, out T payloadResult)
-        {
-            return TryDecodeCore(token, payloadParser, null, out payloadResult);
-        }
-
-        public DecodeResult TryDecode<T>(
-            ReadOnlySpan<char> token,
-            PayloadParser<T> payloadParser,
-            TokenValidationParameters<T> validationParameters,
-            out T payloadResult)
-        {
-            if (validationParameters == null)
-                throw new ArgumentNullException(nameof(validationParameters));
-
-            return TryDecodeCore(token, payloadParser, validationParameters, out payloadResult);
-        }
+        #endregion
 
         DecodeResult TryDecodeCore<T>(
             ReadOnlySpan<byte> utf8token,

--- a/src/LitJWT/JwtDecoder.cs
+++ b/src/LitJWT/JwtDecoder.cs
@@ -208,7 +208,7 @@ namespace LitJWT
 
                     try
                     {
-                        var reader = new System.Text.Json.Utf8JsonReader(bytes.Slice(0, bytesWritten));
+                        var reader = new Utf8JsonReader(bytes.Slice(0, bytesWritten));
                         while (reader.Read())
                         {
                             if (reader.TokenType == JsonTokenType.EndObject) break;
@@ -246,10 +246,10 @@ namespace LitJWT
                     var decodedPayload = bytes.Slice(0, bytesWritten);
                     try
                     {
-                        var reader = new System.Text.Json.Utf8JsonReader(decodedPayload);
+                        var reader = new Utf8JsonReader(decodedPayload);
                         while (reader.Read())
                         {
-                            if (reader.TokenType == System.Text.Json.JsonTokenType.EndObject) break;
+                            if (reader.TokenType == JsonTokenType.EndObject) break;
 
                             if (reader.TokenType == JsonTokenType.PropertyName)
                             {
@@ -368,10 +368,10 @@ namespace LitJWT
                 var decodedPayload = bytes.Slice(0, bytesWritten);
                 try
                 {
-                    var reader = new System.Text.Json.Utf8JsonReader(decodedPayload);
+                    var reader = new Utf8JsonReader(decodedPayload);
                     while (reader.Read())
                     {
-                        if (reader.TokenType == System.Text.Json.JsonTokenType.EndObject) break;
+                        if (reader.TokenType == JsonTokenType.EndObject) break;
 
                         // try to read algorithm span.
                         if (reader.TokenType == JsonTokenType.PropertyName)
@@ -413,10 +413,10 @@ namespace LitJWT
 
                     try
                     {
-                        var reader = new System.Text.Json.Utf8JsonReader(decodedPayload);
+                        var reader = new Utf8JsonReader(decodedPayload);
                         while (reader.Read())
                         {
-                            if (reader.TokenType == System.Text.Json.JsonTokenType.EndObject) break;
+                            if (reader.TokenType == JsonTokenType.EndObject) break;
 
                             if (reader.TokenType == JsonTokenType.PropertyName)
                             {
@@ -549,7 +549,7 @@ namespace LitJWT
 
                     try
                     {
-                        var reader = new System.Text.Json.Utf8JsonReader(bytes.Slice(0, bytesWritten));
+                        var reader = new Utf8JsonReader(bytes.Slice(0, bytesWritten));
                         while (reader.Read())
                         {
                             if (reader.TokenType == JsonTokenType.EndObject) break;
@@ -587,10 +587,10 @@ namespace LitJWT
                     var decodedPayload = bytes.Slice(0, bytesWritten);
                     try
                     {
-                        var reader = new System.Text.Json.Utf8JsonReader(decodedPayload);
+                        var reader = new Utf8JsonReader(decodedPayload);
                         while (reader.Read())
                         {
-                            if (reader.TokenType == System.Text.Json.JsonTokenType.EndObject) break;
+                            if (reader.TokenType == JsonTokenType.EndObject) break;
 
                             if (reader.TokenType == JsonTokenType.PropertyName)
                             {
@@ -679,10 +679,10 @@ namespace LitJWT
                 var decodedPayload = bytes.Slice(0, bytesWritten);
                 try
                 {
-                    var reader = new System.Text.Json.Utf8JsonReader(decodedPayload);
+                    var reader = new Utf8JsonReader(decodedPayload);
                     while (reader.Read())
                     {
-                        if (reader.TokenType == System.Text.Json.JsonTokenType.EndObject) break;
+                        if (reader.TokenType == JsonTokenType.EndObject) break;
 
                         // try to read algorithm span.
                         if (reader.TokenType == JsonTokenType.PropertyName)
@@ -724,10 +724,10 @@ namespace LitJWT
 
                     try
                     {
-                        var reader = new System.Text.Json.Utf8JsonReader(decodedPayload);
+                        var reader = new Utf8JsonReader(decodedPayload);
                         while (reader.Read())
                         {
-                            if (reader.TokenType == System.Text.Json.JsonTokenType.EndObject) break;
+                            if (reader.TokenType == JsonTokenType.EndObject) break;
 
                             if (reader.TokenType == JsonTokenType.PropertyName)
                             {

--- a/src/LitJWT/JwtDecoder.cs
+++ b/src/LitJWT/JwtDecoder.cs
@@ -6,7 +6,7 @@ using System.Text.Json;
 namespace LitJWT
 {
     public delegate T PayloadParser<T>(ReadOnlySpan<byte> payload);
-    public delegate bool LifetimeValidator<T>(DateTimeOffset? notBefore, DateTimeOffset? expires, T token, TokenValidationParameters<T> parameters);
+    public delegate DecodeResult LifetimeValidator<T>(DateTimeOffset? notBefore, DateTimeOffset? expires, T token, TokenValidationParameters<T> parameters);
     internal delegate T InternalPayloadParser<T>(ReadOnlySpan<byte> payload, JsonSerializerOptions serializerOptions);
 
     public enum DecodeResult

--- a/src/LitJWT/JwtDecoder.cs
+++ b/src/LitJWT/JwtDecoder.cs
@@ -172,11 +172,9 @@ namespace LitJWT
         }
 
         public DecodeResult TryDecode<T>(ReadOnlySpan<byte> utf8token, out T payloadResult)
-            => TryDecodeCore(
-                utf8token,
-                InternalPayloadParser<T>,
-                null,
-                out payloadResult);
+        {
+            return TryDecodeCore(utf8token, InternalPayloadParser<T>, null, out payloadResult);
+        }
 
         public DecodeResult TryDecode<T>(
             ReadOnlySpan<byte> utf8token,
@@ -187,18 +185,13 @@ namespace LitJWT
                 throw new ArgumentNullException(nameof(validationParameters));
 
             return TryDecodeCore(
-                utf8token,
-                InternalPayloadParser<T>,
-                validationParameters,
-                out payloadResult);
+                utf8token, InternalPayloadParser<T>, validationParameters, out payloadResult);
         }
 
         public DecodeResult TryDecode<T>(string token, out T payloadResult)
-            => TryDecodeCore(
-                token.AsSpan(),
-                InternalPayloadParser<T>,
-                null,
-                out payloadResult);
+        {
+            return TryDecodeCore(token.AsSpan(), InternalPayloadParser<T>, null, out payloadResult);
+        }
 
         public DecodeResult TryDecode<T>(
             string token, TokenValidationParameters<T> validationParameters, out T payloadResult)
@@ -207,18 +200,13 @@ namespace LitJWT
                 throw new ArgumentNullException(nameof(validationParameters));
 
             return TryDecodeCore(
-                token.AsSpan(),
-                InternalPayloadParser<T>,
-                null,
-                out payloadResult);
+                token.AsSpan(), InternalPayloadParser<T>, null, out payloadResult);
         }
 
         public DecodeResult TryDecode<T>(ReadOnlySpan<char> token, out T payloadResult)
-            => TryDecodeCore(
-                token,
-                InternalPayloadParser<T>,
-                null,
-                out payloadResult);
+        {
+            return TryDecodeCore(token, InternalPayloadParser<T>, null, out payloadResult);
+        }
 
         public DecodeResult TryDecode<T>(
             ReadOnlySpan<char> token,
@@ -229,10 +217,7 @@ namespace LitJWT
                 throw new ArgumentNullException(nameof(validationParameters));
 
             return TryDecodeCore(
-                token,
-                InternalPayloadParser<T>,
-                validationParameters,
-                out payloadResult);
+                token,  InternalPayloadParser<T>, validationParameters, out payloadResult);
         }
 
         public DecodeResult TryDecode<T>(
@@ -252,12 +237,14 @@ namespace LitJWT
             if (validationParameters == null)
                 throw new ArgumentNullException(nameof(validationParameters));
 
-            return TryDecodeCore(utf8token, payloadParser, validationParameters, out payloadResult);
+            return TryDecodeCore(
+                utf8token, payloadParser, validationParameters, out payloadResult);
         }
 
-        public DecodeResult TryDecode<T>(string token, PayloadParser<T> payloadParser, out T payloadResult)
+        public DecodeResult TryDecode<T>(
+            string token, PayloadParser<T> payloadParser, out T payloadResult)
         {
-            return TryDecode<T>(token.AsSpan(), payloadParser, out payloadResult);
+            return TryDecode(token.AsSpan(), payloadParser, out payloadResult);
         }
 
         public DecodeResult TryDecode<T>(
@@ -266,13 +253,12 @@ namespace LitJWT
             TokenValidationParameters<T> validationParameters,
             out T payloadResult)
         {
-            throw new NotImplementedException();
+            return TryDecodeCore(
+                token.AsSpan(), payloadParser, validationParameters, out payloadResult);
         }
 
         public DecodeResult TryDecode<T>(
-            ReadOnlySpan<char> token,
-            PayloadParser<T> payloadParser,
-            out T payloadResult)
+            ReadOnlySpan<char> token, PayloadParser<T> payloadParser, out T payloadResult)
         {
             return TryDecodeCore(token, payloadParser, null, out payloadResult);
         }

--- a/src/LitJWT/JwtDecoder.cs
+++ b/src/LitJWT/JwtDecoder.cs
@@ -170,24 +170,73 @@ namespace LitJWT
         }
 
         public DecodeResult TryDecode<T>(ReadOnlySpan<byte> utf8token, out T payloadResult)
-            => TryDecodeCore(utf8token, static (x, options) => JsonSerializer.Deserialize<T>(x, options), out payloadResult);
-        
-        public DecodeResult TryDecode<T>(ReadOnlySpan<byte> utf8token, TokenValidationParameters<T> validationParameters, out T payloadResult)
-            => throw new NotImplementedException();
+            => TryDecodeCore(
+                utf8token,
+                static (x, options) => JsonSerializer.Deserialize<T>(x, options),
+                null,
+                out payloadResult);
+
+        public DecodeResult TryDecode<T>(
+            ReadOnlySpan<byte> utf8token,
+            TokenValidationParameters<T> validationParameters,
+            out T payloadResult)
+        {
+            if (validationParameters == null)
+                throw new ArgumentNullException(nameof(validationParameters));
+
+            return TryDecodeCore(
+                utf8token,
+                static (x, options) => JsonSerializer.Deserialize<T>(x, options),
+                validationParameters,
+                out payloadResult);
+        }
 
         public DecodeResult TryDecode<T>(string token, out T payloadResult)
-            => TryDecodeCore(token.AsSpan(), static (x, options) => JsonSerializer.Deserialize<T>(x, options), out payloadResult);
+            => TryDecodeCore(
+                token.AsSpan(),
+                static (x, options) => JsonSerializer.Deserialize<T>(x, options),
+                null,
+                out payloadResult);
 
-        public DecodeResult TryDecode<T>(string token, TokenValidationParameters<T> validationParameters, out T payloadResult)
-            => throw new NotImplementedException();
+        public DecodeResult TryDecode<T>(
+            string token, TokenValidationParameters<T> validationParameters, out T payloadResult)
+        {
+            if (validationParameters == null)
+                throw new ArgumentNullException(nameof(validationParameters));
+
+            return TryDecodeCore(
+                token.AsSpan(),
+                static (x, options) => JsonSerializer.Deserialize<T>(x, options),
+                null,
+                out payloadResult);
+        }
 
         public DecodeResult TryDecode<T>(ReadOnlySpan<char> token, out T payloadResult)
-            => TryDecodeCore(token, static (x, options) => JsonSerializer.Deserialize<T>(x, options), out payloadResult);
-        
-        public DecodeResult TryDecode<T>(ReadOnlySpan<char> token, TokenValidationParameters<T> validationParameters, out T payloadResult)
-            => throw new NotImplementedException();
+            => TryDecodeCore(
+                token,
+                static (x, options) => JsonSerializer.Deserialize<T>(x, options),
+                null,
+                out payloadResult);
 
-        public DecodeResult TryDecode<T>(ReadOnlySpan<byte> utf8token, PayloadParser<T> payloadParser, out T payloadResult)
+        public DecodeResult TryDecode<T>(
+            ReadOnlySpan<char> token,
+            TokenValidationParameters<T> validationParameters,
+            out T payloadResult)
+        {
+            if (validationParameters == null)
+                throw new ArgumentNullException(nameof(validationParameters));
+
+            return TryDecodeCore(
+                token,
+                static (x, options) => JsonSerializer.Deserialize<T>(x, options),
+                validationParameters,
+                out payloadResult);
+        }
+
+        public DecodeResult TryDecode<T>(
+            ReadOnlySpan<byte> utf8token,
+            PayloadParser<T> payloadParser,
+            out T payloadResult)
         {
             Split(utf8token, out var header, out var payload, out var headerAndPayload, out var signature);
 
@@ -522,7 +571,7 @@ namespace LitJWT
         DecodeResult TryDecodeCore<T>(
             ReadOnlySpan<byte> utf8token,
             InternalPayloadParser<T> payloadParser,
-            TokenValidationParameters<T> validationParameters,
+            TokenValidationParameters<T>? validationParameters,
             out T payloadResult)
         {
             Split(
@@ -655,7 +704,7 @@ namespace LitJWT
         DecodeResult TryDecodeCore<T>(
             ReadOnlySpan<char> token,
             InternalPayloadParser<T> payloadParser,
-            TokenValidationParameters<T> validationParameters,
+            TokenValidationParameters<T>? validationParameters,
             out T payloadResult)
         {
             Split(

--- a/src/LitJWT/JwtDecoder.cs
+++ b/src/LitJWT/JwtDecoder.cs
@@ -6,7 +6,14 @@ using System.Text.Json;
 namespace LitJWT
 {
     public delegate T PayloadParser<T>(ReadOnlySpan<byte> payload);
-    public delegate DecodeResult LifetimeValidator<T>(DateTimeOffset? notBefore, DateTimeOffset? expires, T token, TokenValidationParameters<T> parameters);
+
+    public delegate DecodeResult LifetimeValidator<T>(
+        DateTimeOffset? notBefore,
+        DateTimeOffset? expires,
+        T token, 
+        TokenValidationParameters<T> parameters);
+
+    public delegate DateTimeOffset GetCurrentDateTime();
 
     public enum DecodeResult
     {
@@ -27,6 +34,7 @@ namespace LitJWT
         public bool ValidateLifetime { get; set; } = true;
         public TimeSpan ClockSkew { get; set; } = DefaultClockSkew;
         public LifetimeValidator<T>? LifetimeValidator { get; set; } = null;
+        public GetCurrentDateTime? Now { get; set; } = () => DateTimeOffset.UtcNow;
 
         public static readonly TimeSpan DefaultClockSkew = TimeSpan.FromMinutes(5);
     }
@@ -610,7 +618,7 @@ namespace LitJWT
                     validationParameters);
             }
 
-            DateTimeOffset now = DateTimeOffset.UtcNow;
+            DateTimeOffset now = validationParameters.Now?.Invoke() ?? DateTimeOffset.UtcNow;
             if (notBeforeDateTimeOffset.HasValue)
             {
                 TimeSpan diff = now - notBeforeDateTimeOffset.Value;

--- a/src/LitJWT/JwtDecoder.cs
+++ b/src/LitJWT/JwtDecoder.cs
@@ -58,7 +58,12 @@ namespace LitJWT
             this.serializerOptions = serializerOptions;
         }
 
-        static void Split(ReadOnlySpan<char> text, out ReadOnlySpan<char> header, out ReadOnlySpan<char> payload, out ReadOnlySpan<char> headerAndPayload, out ReadOnlySpan<char> signature)
+        static void Split(
+            ReadOnlySpan<char> text,
+            out ReadOnlySpan<char> header,
+            out ReadOnlySpan<char> payload,
+            out ReadOnlySpan<char> headerAndPayload,
+            out ReadOnlySpan<char> signature)
         {
             header = default;
             payload = default;
@@ -87,7 +92,12 @@ namespace LitJWT
             }
         }
 
-        static void Split(ReadOnlySpan<byte> text, out ReadOnlySpan<byte> header, out ReadOnlySpan<byte> payload, out ReadOnlySpan<byte> headerAndPayload, out ReadOnlySpan<byte> signature)
+        static void Split(
+            ReadOnlySpan<byte> text,
+            out ReadOnlySpan<byte> header,
+            out ReadOnlySpan<byte> payload,
+            out ReadOnlySpan<byte> headerAndPayload,
+            out ReadOnlySpan<byte> signature)
         {
             header = default;
             payload = default;
@@ -159,9 +169,14 @@ namespace LitJWT
             }
         }
 
-        public DecodeResult TryDecode<T>(ReadOnlySpan<byte> utf8token, out T payloadResult) => TryDecodeCore(utf8token, static (x, options) => JsonSerializer.Deserialize<T>(x, options), out payloadResult);
-        public DecodeResult TryDecode<T>(string token, out T payloadResult) => TryDecodeCore(token.AsSpan(), static (x, options) => JsonSerializer.Deserialize<T>(x, options), out payloadResult);
-        public DecodeResult TryDecode<T>(ReadOnlySpan<char> token, out T payloadResult) => TryDecodeCore(token, static (x, options) => JsonSerializer.Deserialize<T>(x, options), out payloadResult);
+        public DecodeResult TryDecode<T>(ReadOnlySpan<byte> utf8token, out T payloadResult)
+            => TryDecodeCore(utf8token, static (x, options) => JsonSerializer.Deserialize<T>(x, options), out payloadResult);
+
+        public DecodeResult TryDecode<T>(string token, out T payloadResult)
+            => TryDecodeCore(token.AsSpan(), static (x, options) => JsonSerializer.Deserialize<T>(x, options), out payloadResult);
+
+        public DecodeResult TryDecode<T>(ReadOnlySpan<char> token, out T payloadResult)
+            => TryDecodeCore(token, static (x, options) => JsonSerializer.Deserialize<T>(x, options), out payloadResult);
 
         public DecodeResult TryDecode<T>(ReadOnlySpan<byte> utf8token, PayloadParser<T> payloadParser, out T payloadResult)
         {
@@ -302,9 +317,15 @@ namespace LitJWT
             return TryDecode<T>(token.AsSpan(), payloadParser, out payloadResult);
         }
 
-        public DecodeResult TryDecode<T>(ReadOnlySpan<char> token, PayloadParser<T> payloadParser, out T payloadResult)
+        public DecodeResult TryDecode<T>(
+            ReadOnlySpan<char> token, PayloadParser<T> payloadParser, out T payloadResult)
         {
-            Split(token, out var header, out var payload, out var headerAndPayload, out var signature);
+            Split(
+                token,
+                out var header,
+                out var payload,
+                out var headerAndPayload,
+                out var signature);
 
             IJwtAlgorithm algorithm = null;
 
@@ -462,9 +483,15 @@ namespace LitJWT
         }
 
         // note:ugly copy and paste code...
-        DecodeResult TryDecodeCore<T>(ReadOnlySpan<byte> utf8token, InternalPayloadParser<T> payloadParser, out T payloadResult)
+        DecodeResult TryDecodeCore<T>(
+            ReadOnlySpan<byte> utf8token, InternalPayloadParser<T> payloadParser, out T payloadResult)
         {
-            Split(utf8token, out var header, out var payload, out var headerAndPayload, out var signature);
+            Split(
+                utf8token,
+                out var header,
+                out var payload,
+                out var headerAndPayload,
+                out var signature);
 
             IJwtAlgorithm algorithm = null;
 
@@ -596,9 +623,15 @@ namespace LitJWT
             return DecodeResult.Success;
         }
 
-        DecodeResult TryDecodeCore<T>(ReadOnlySpan<char> token, InternalPayloadParser<T> payloadParser, out T payloadResult)
+        DecodeResult TryDecodeCore<T>(
+            ReadOnlySpan<char> token, InternalPayloadParser<T> payloadParser, out T payloadResult)
         {
-            Split(token, out var header, out var payload, out var headerAndPayload, out var signature);
+            Split(
+                token,
+                out var header,
+                out var payload,
+                out var headerAndPayload,
+                out var signature);
 
             IJwtAlgorithm algorithm = null;
 

--- a/src/LitJWT/JwtDecoder.cs
+++ b/src/LitJWT/JwtDecoder.cs
@@ -171,12 +171,21 @@ namespace LitJWT
 
         public DecodeResult TryDecode<T>(ReadOnlySpan<byte> utf8token, out T payloadResult)
             => TryDecodeCore(utf8token, static (x, options) => JsonSerializer.Deserialize<T>(x, options), out payloadResult);
+        
+        public DecodeResult TryDecode<T>(ReadOnlySpan<byte> utf8token, TokenValidationParameters<T> validationParameters, out T payloadResult)
+            => throw new NotImplementedException();
 
         public DecodeResult TryDecode<T>(string token, out T payloadResult)
             => TryDecodeCore(token.AsSpan(), static (x, options) => JsonSerializer.Deserialize<T>(x, options), out payloadResult);
 
+        public DecodeResult TryDecode<T>(string token, TokenValidationParameters<T> validationParameters, out T payloadResult)
+            => throw new NotImplementedException();
+
         public DecodeResult TryDecode<T>(ReadOnlySpan<char> token, out T payloadResult)
             => TryDecodeCore(token, static (x, options) => JsonSerializer.Deserialize<T>(x, options), out payloadResult);
+        
+        public DecodeResult TryDecode<T>(ReadOnlySpan<char> token, TokenValidationParameters<T> validationParameters, out T payloadResult)
+            => throw new NotImplementedException();
 
         public DecodeResult TryDecode<T>(ReadOnlySpan<byte> utf8token, PayloadParser<T> payloadParser, out T payloadResult)
         {
@@ -312,9 +321,27 @@ namespace LitJWT
             return DecodeResult.Success;
         }
 
+        public DecodeResult TryDecode<T>(
+            ReadOnlySpan<byte> utf8token,
+            PayloadParser<T> payloadParser,
+            TokenValidationParameters<T> validationParameters,
+            out T payloadResult)
+        {
+            throw new NotImplementedException();
+        }
+
         public DecodeResult TryDecode<T>(string token, PayloadParser<T> payloadParser, out T payloadResult)
         {
             return TryDecode<T>(token.AsSpan(), payloadParser, out payloadResult);
+        }
+
+        public DecodeResult TryDecode<T>(
+            string token,
+            PayloadParser<T> payloadParser,
+            TokenValidationParameters<T> validationParameters,
+            out T payloadResult)
+        {
+            throw new NotImplementedException();
         }
 
         public DecodeResult TryDecode<T>(
@@ -480,6 +507,15 @@ namespace LitJWT
 
             // all ok
             return DecodeResult.Success;
+        }
+
+        public DecodeResult TryDecode<T>(
+            ReadOnlySpan<char> token,
+            PayloadParser<T> payloadParser,
+            TokenValidationParameters<T> validationParameters,
+            out T payloadResult)
+        {
+            throw new NotImplementedException();
         }
 
         // note:ugly copy and paste code...

--- a/src/LitJWT/JwtDecoder.cs
+++ b/src/LitJWT/JwtDecoder.cs
@@ -605,22 +605,22 @@ namespace LitJWT
             TokenValidationParameters<T>? validationParameters,
             T payloadResult)
         {
-            if (validationParameters is not null
+            if (validationParameters != null
                 && !validationParameters.ValidateLifetime
-                && validationParameters.LifetimeValidator is null)
+                && validationParameters.LifetimeValidator == null)
             {
                 return DecodeResult.Success;
             }
 
-            DateTimeOffset? notBeforeDateTimeOffset = notBeforeUnixEpoch is null
+            DateTimeOffset? notBeforeDateTimeOffset = notBeforeUnixEpoch == null
                 ? null
                 : DateTimeOffset.FromUnixTimeSeconds(notBeforeUnixEpoch.Value);
 
-            DateTimeOffset? expiryDateTimeOffset = expiryUnixEpoch is null
+            DateTimeOffset? expiryDateTimeOffset = expiryUnixEpoch == null
                 ? null
                 : DateTimeOffset.FromUnixTimeSeconds(expiryUnixEpoch.Value);
 
-            if (validationParameters is null)
+            if (validationParameters == null)
             {
                 return DefaultLifetimeValidation(
                     notBeforeDateTimeOffset,
@@ -628,7 +628,7 @@ namespace LitJWT
                     DateTimeOffset.UtcNow);
             }
 
-            if (validationParameters.LifetimeValidator is not null)
+            if (validationParameters.LifetimeValidator != null)
             {
                 return validationParameters.LifetimeValidator(
                     notBeforeDateTimeOffset,

--- a/src/LitJWT/JwtDecoder.cs
+++ b/src/LitJWT/JwtDecoder.cs
@@ -236,20 +236,27 @@ namespace LitJWT
         public DecodeResult TryDecode<T>(
             string token, PayloadParser<T> payloadParser, out T payloadResult)
         {
-            return TryDecode(token.AsSpan(), payloadParser, out payloadResult);
+            if (payloadParser == null)
+                throw new ArgumentNullException(nameof(payloadParser));
+
+            return TryDecodeCore(token.AsSpan(), payloadParser, null, out payloadResult);
         }
 
         public DecodeResult TryDecode<T>(
             ReadOnlySpan<char> token, PayloadParser<T> payloadParser, out T payloadResult)
         {
+            if (payloadParser == null)
+                throw new ArgumentNullException(nameof(payloadParser));
+
             return TryDecodeCore(token, payloadParser, null, out payloadResult);
         }
 
         public DecodeResult TryDecode<T>(
-            ReadOnlySpan<byte> utf8token,
-            PayloadParser<T> payloadParser,
-            out T payloadResult)
+            ReadOnlySpan<byte> utf8token, PayloadParser<T> payloadParser, out T payloadResult)
         {
+            if (payloadParser == null)
+                throw new ArgumentNullException(nameof(payloadParser));
+
             return TryDecodeCore(utf8token, payloadParser, null, out payloadResult);
         }
         #endregion
@@ -261,6 +268,12 @@ namespace LitJWT
             TokenValidationParameters<T> validationParameters,
             out T payloadResult)
         {
+            if (payloadParser == null)
+                throw new ArgumentNullException(nameof(payloadParser));
+
+            if (validationParameters == null)
+                throw new ArgumentNullException(nameof(validationParameters));
+
             return TryDecodeCore(
                 token.AsSpan(), payloadParser, validationParameters, out payloadResult);
         }
@@ -271,6 +284,9 @@ namespace LitJWT
             TokenValidationParameters<T> validationParameters,
             out T payloadResult)
         {
+            if (payloadParser == null)
+                throw new ArgumentNullException(nameof(payloadParser));
+
             if (validationParameters == null)
                 throw new ArgumentNullException(nameof(validationParameters));
 
@@ -283,6 +299,9 @@ namespace LitJWT
             TokenValidationParameters<T> validationParameters,
             out T payloadResult)
         {
+            if (payloadParser == null)
+                throw new ArgumentNullException(nameof(payloadParser));
+
             if (validationParameters == null)
                 throw new ArgumentNullException(nameof(validationParameters));
 

--- a/src/LitJWT/LitJWT.csproj
+++ b/src/LitJWT/LitJWT.csproj
@@ -9,6 +9,7 @@
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+		<Nullable>Enable</Nullable>
 		<NoWarn>1701;1702;1705;1591</NoWarn>
 		<Company>Cysharp</Company>
 


### PR DESCRIPTION
## Goals

Allowing more flexible token lifetime validation.

Existing APIs remain unchanged and do not break compatibility.

New APIs allow client code to do a flexible token lifetime validation:
- Client code can now specify a clock skew for the lifetime validation
  - Accounting for clock skew is something recommended in JWT RFC (sections [4.1.4](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4) and [4.1.5](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5) on [RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519))
- Client code can now provide their own lifetime validation callback.
- Client code can now skip lifetime validation altogether.

## Code examples

Specifying clock skew when validating lifetime:

```csharp
string token = "...";
JwtDecoder decoder = new(...);

var tokenValidationParameters = new TokenValidationParameters<TokenModel>()
{
    ClockSkew = TimeSpan.FromMinutes(5)
};

DecodeResult result = decoder.TryDecode<TokenModel>(token, tokenValidationParameters, out TokenModel result);
```

------

Specifying your own lifetime validator function when validating lifetime:

```csharp
string token = "...";
JwtDecoder decoder = new(...);

var tokenValidationParameters = new TokenValidationParameters<TokenModel>()
{
    LifetimeValidator = (before, expire, token, parameters) =>
    {
        DateTimeOffset now = DateTimeOffset.UtcNow;
        if ((now - before).Duration() > parameters.ClockSkew)
            return DecodeResult.FailedVerifyNotBefore;
        if ((expire - now).Duration() > parameters.ClockSkew)
            return DecodeResult.FailedVerifyExpire;

        return DecodeResult.Success;
    }
};

DecodeResult result = decoder.TryDecode<TokenModel>(token, tokenValidationParameters, out TokenModel result);
```

------

Skip lifetime validation altogether:

```csharp
string expiredToken = "...";
JwtDecoder decoder = new(...);

var tokenValidationParameters = new TokenValidationParameters<TokenModel>()
{
    ValidateLifetime = false
};

DecodeResult result = decoder.TryDecode<TokenModel>(token, tokenValidationParameters, out TokenModel result);
// result is different than DecodeResult.FailedVerifyNotBefore and DecodeResult.FailedVerifyExpire
```

## Work done / to review

- Adds new `TokenValidationParameters` class
  - This class allows (for now, although it can be extended) how the token lifetime ("not before" and "expire" token properties) are validated
- Adds new `JwtDecoder.TryDecode` overloads accepting the new `TokenValidationParameters` class.
  - The existing APIs are not affected by these changes, nor are their behaviours changed.
- Removes internal delegate `InternalPayloadParser`
  - By removing this delegate, all `TryDecode` public APIs can rely on internal `TryDecodeCore` methods.
  - By removing this delegate, all duplicated copy-pasted implementations of `TryDecode` could be removed.
- Add new test cases to cover all what was implemented.
- Tidy up a little bit some code in the JwtDecoder class.