### PR TITLE
Fix misjudgment of exp / nbf if payload contains nested object

### DIFF
--- a/src/LitJWT/JwtDecoder.cs
+++ b/src/LitJWT/JwtDecoder.cs
@@ -516,7 +516,7 @@ namespace LitJWT
                         {
                             if (reader.TokenType == System.Text.Json.JsonTokenType.EndObject) break;
 
-                            if (reader.TokenType == JsonTokenType.PropertyName)
+                            if (reader.CurrentDepth == 1 && reader.TokenType == JsonTokenType.PropertyName)
                             {
                                 if (reader.ValueTextEquals(JwtConstantsUtf8.Expiration))
                                 {

--- a/src/LitJWT/JwtDecoder.cs
+++ b/src/LitJWT/JwtDecoder.cs
@@ -215,8 +215,6 @@ namespace LitJWT
                         var reader = new System.Text.Json.Utf8JsonReader(decodedPayload);
                         while (reader.Read())
                         {
-                            if (reader.TokenType == System.Text.Json.JsonTokenType.EndObject) break;
-
                             if (reader.CurrentDepth == 1 && reader.TokenType == JsonTokenType.PropertyName)
                             {
                                 if (reader.ValueTextEquals(JwtConstantsUtf8.Expiration))
@@ -358,8 +356,6 @@ namespace LitJWT
                         var reader = new System.Text.Json.Utf8JsonReader(decodedPayload);
                         while (reader.Read())
                         {
-                            if (reader.TokenType == System.Text.Json.JsonTokenType.EndObject) break;
-
                             if (reader.CurrentDepth == 1 && reader.TokenType == JsonTokenType.PropertyName)
                             {
                                 if (reader.ValueTextEquals(JwtConstantsUtf8.Expiration))
@@ -514,8 +510,6 @@ namespace LitJWT
                         var reader = new System.Text.Json.Utf8JsonReader(decodedPayload);
                         while (reader.Read())
                         {
-                            if (reader.TokenType == System.Text.Json.JsonTokenType.EndObject) break;
-
                             if (reader.CurrentDepth == 1 && reader.TokenType == JsonTokenType.PropertyName)
                             {
                                 if (reader.ValueTextEquals(JwtConstantsUtf8.Expiration))
@@ -652,8 +646,6 @@ namespace LitJWT
                         var reader = new System.Text.Json.Utf8JsonReader(decodedPayload);
                         while (reader.Read())
                         {
-                            if (reader.TokenType == System.Text.Json.JsonTokenType.EndObject) break;
-
                             if (reader.CurrentDepth == 1 && reader.TokenType == JsonTokenType.PropertyName)
                             {
                                 if (reader.ValueTextEquals(JwtConstantsUtf8.Expiration))

--- a/src/LitJWT/JwtDecoder.cs
+++ b/src/LitJWT/JwtDecoder.cs
@@ -217,7 +217,7 @@ namespace LitJWT
                         {
                             if (reader.TokenType == System.Text.Json.JsonTokenType.EndObject) break;
 
-                            if (reader.TokenType == JsonTokenType.PropertyName)
+                            if (reader.CurrentDepth == 1 && reader.TokenType == JsonTokenType.PropertyName)
                             {
                                 if (reader.ValueTextEquals(JwtConstantsUtf8.Expiration))
                                 {
@@ -360,7 +360,7 @@ namespace LitJWT
                         {
                             if (reader.TokenType == System.Text.Json.JsonTokenType.EndObject) break;
 
-                            if (reader.TokenType == JsonTokenType.PropertyName)
+                            if (reader.CurrentDepth == 1 && reader.TokenType == JsonTokenType.PropertyName)
                             {
                                 if (reader.ValueTextEquals(JwtConstantsUtf8.Expiration))
                                 {
@@ -654,7 +654,7 @@ namespace LitJWT
                         {
                             if (reader.TokenType == System.Text.Json.JsonTokenType.EndObject) break;
 
-                            if (reader.TokenType == JsonTokenType.PropertyName)
+                            if (reader.CurrentDepth == 1 && reader.TokenType == JsonTokenType.PropertyName)
                             {
                                 if (reader.ValueTextEquals(JwtConstantsUtf8.Expiration))
                                 {

--- a/tests/LitJWT.Tests/DecodeTest.cs
+++ b/tests/LitJWT.Tests/DecodeTest.cs
@@ -115,6 +115,24 @@ namespace LitJWT.Tests
                 var decodeResult = decoder.TryDecode(result, x => JsonConvert.DeserializeObject<Payload>(Encoding.UTF8.GetString(x)), out var decodedPayload);
                 decodeResult.Should().Be(DecodeResult.Success);
             }
+
+            {
+                var nested = new Payload { Bar = 2, Foo = "foo2" };
+                var payload = new PayloadExp { Bar = 1, Foo = "foo", Nested = nested, exp = (DateTimeOffset.UtcNow - TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
+                var jwt = encoder.Encode(payload, null);
+
+                var decodeResult = decoder.TryDecode(jwt, out PayloadExp decodedPayload);
+                decodeResult.Should().Be(DecodeResult.FailedVerifyExpire);
+            }
+
+            {
+                var nested = new Payload { Bar = 2, Foo = "foo2" };
+                var payload = new PayloadExp { Bar = 1, Foo = "foo", Nested = nested, exp = (DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
+                var jwt = encoder.Encode(payload, null);
+
+                var decodeResult = decoder.TryDecode(jwt, out PayloadExp decodedPayload);
+                decodeResult.Should().Be(DecodeResult.Success);
+            }
         }
 
         [Fact]
@@ -142,6 +160,24 @@ namespace LitJWT.Tests
 
                 var decodeResult = decoder.TryDecode(result, x => JsonConvert.DeserializeObject<Payload>(Encoding.UTF8.GetString(x)), out var decodedPayload);
 
+                decodeResult.Should().Be(DecodeResult.Success);
+            }
+
+            {
+                var nested = new Payload { Bar = 2, Foo = "foo2" };
+                var payload = new PayloadNbf { Bar = 1, Foo = "foo", Nested = nested, nbf = (DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
+                var jwt = encoder.Encode(payload, null);
+
+                var decodeResult = decoder.TryDecode(jwt, out PayloadNbf decodedPayload);
+                decodeResult.Should().Be(DecodeResult.FailedVerifyNotBefore);
+            }
+
+            {
+                var nested = new Payload { Bar = 2, Foo = "foo2" };
+                var payload = new PayloadNbf { Bar = 1, Foo = "foo", Nested = nested, nbf = (DateTimeOffset.UtcNow - TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
+                var jwt = encoder.Encode(payload, null);
+
+                var decodeResult = decoder.TryDecode(jwt, out PayloadNbf decodedPayload);
                 decodeResult.Should().Be(DecodeResult.Success);
             }
         }
@@ -232,6 +268,24 @@ namespace LitJWT.Tests
                 var decodeResult = decoder.TryDecode(result, x => JsonConvert.DeserializeObject<Payload>(Encoding.UTF8.GetString(x)), out var decodedPayload);
                 decodeResult.Should().Be(DecodeResult.Success);
             }
+
+            {
+                var nested = new Payload { Bar = 2, Foo = "foo2" };
+                var payload = new PayloadExp { Bar = 1, Foo = "foo", Nested = nested, exp = (DateTimeOffset.UtcNow - TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
+                var jwt = encoder.EncodeAsUtf8Bytes(payload, null);
+
+                var decodeResult = decoder.TryDecode(jwt, out PayloadExp decodedPayload);
+                decodeResult.Should().Be(DecodeResult.FailedVerifyExpire);
+            }
+
+            {
+                var nested = new Payload { Bar = 2, Foo = "foo2" };
+                var payload = new PayloadExp { Bar = 1, Foo = "foo", Nested = nested, exp = (DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
+                var jwt = encoder.EncodeAsUtf8Bytes(payload, null);
+
+                var decodeResult = decoder.TryDecode(jwt, out PayloadExp decodedPayload);
+                decodeResult.Should().Be(DecodeResult.Success);
+            }
         }
 
         [Fact]
@@ -258,6 +312,26 @@ namespace LitJWT.Tests
 
 
                 var decodeResult = decoder.TryDecode(result, x => JsonConvert.DeserializeObject<Payload>(Encoding.UTF8.GetString(x)), out var decodedPayload);
+
+                decodeResult.Should().Be(DecodeResult.Success);
+            }
+            {
+                var nested = new Payload { Bar = 2, Foo = "foo2" };
+                var payload = new PayloadNbf { Bar = 1, Foo = "foo", Nested = nested, nbf = (DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
+                var jwt = encoder.EncodeAsUtf8Bytes(payload, null);
+
+
+                var decodeResult = decoder.TryDecode(jwt, out PayloadNbf decodedPayload);
+
+                decodeResult.Should().Be(DecodeResult.FailedVerifyNotBefore);
+            }
+            {
+                var nested = new Payload { Bar = 2, Foo = "foo2" };
+                var payload = new PayloadNbf { Bar = 1, Foo = "foo", Nested = nested, nbf = (DateTimeOffset.UtcNow - TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
+                var jwt = encoder.EncodeAsUtf8Bytes(payload, null);
+
+
+                var decodeResult = decoder.TryDecode(jwt, out PayloadNbf decodedPayload);
 
                 decodeResult.Should().Be(DecodeResult.Success);
             }

--- a/tests/LitJWT.Tests/DecodeTest.cs
+++ b/tests/LitJWT.Tests/DecodeTest.cs
@@ -22,12 +22,14 @@ namespace LitJWT.Tests
         {
             public string Foo { get; set; }
             public int Bar { get; set; }
+            public Payload Nested { get; set; }
             public long nbf { get; set; }
         }
         public class PayloadExp
         {
             public string Foo { get; set; }
             public int Bar { get; set; }
+            public Payload Nested { get; set; }
             public long exp { get; set; }
         }
         [Fact]
@@ -97,7 +99,8 @@ namespace LitJWT.Tests
             var decoder = new JwtDecoder(new LitJWT.Algorithms.HS256Algorithm(key));
 
             {
-                var payload = new PayloadExp { Bar = 1, Foo = "foo", exp = (DateTimeOffset.UtcNow - TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
+                var nested = new Payload { Bar = 2, Foo = "foo2" };
+                var payload = new PayloadExp { Bar = 1, Foo = "foo", Nested = nested, exp = (DateTimeOffset.UtcNow - TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
                 var result = encoder.Encode(payload, null, (x, writer) => writer.Write(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(x))));
 
                 var decodeResult = decoder.TryDecode(result, x => JsonConvert.DeserializeObject<Payload>(Encoding.UTF8.GetString(x)), out var decodedPayload);
@@ -105,7 +108,8 @@ namespace LitJWT.Tests
             }
 
             {
-                var payload = new PayloadExp { Bar = 1, Foo = "foo", exp = (DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
+                var nested = new Payload { Bar = 2, Foo = "foo2" };
+                var payload = new PayloadExp { Bar = 1, Foo = "foo", Nested = nested, exp = (DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
                 var result = encoder.Encode(payload, null, (x, writer) => writer.Write(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(x))));
 
                 var decodeResult = decoder.TryDecode(result, x => JsonConvert.DeserializeObject<Payload>(Encoding.UTF8.GetString(x)), out var decodedPayload);
@@ -121,7 +125,8 @@ namespace LitJWT.Tests
             var decoder = new JwtDecoder(new LitJWT.Algorithms.HS256Algorithm(key));
 
             {
-                var payload = new PayloadNbf { Bar = 1, Foo = "foo", nbf = (DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
+                var nested = new Payload { Bar = 2, Foo = "foo2" };
+                var payload = new PayloadNbf { Bar = 1, Foo = "foo", Nested = nested, nbf = (DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
                 var result = encoder.Encode(payload, null, (x, writer) => writer.Write(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(x))));
 
 
@@ -130,7 +135,8 @@ namespace LitJWT.Tests
                 decodeResult.Should().Be(DecodeResult.FailedVerifyNotBefore);
             }
             {
-                var payload = new PayloadNbf { Bar = 1, Foo = "foo", nbf = (DateTimeOffset.UtcNow - TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
+                var nested = new Payload { Bar = 2, Foo = "foo2" };
+                var payload = new PayloadNbf { Bar = 1, Foo = "foo", Nested = nested, nbf = (DateTimeOffset.UtcNow - TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
                 var result = encoder.Encode(payload, null, (x, writer) => writer.Write(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(x))));
 
 
@@ -210,7 +216,8 @@ namespace LitJWT.Tests
             var decoder = new JwtDecoder(new LitJWT.Algorithms.HS256Algorithm(key));
 
             {
-                var payload = new PayloadExp { Bar = 1, Foo = "foo", exp = (DateTimeOffset.UtcNow - TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
+                var nested = new Payload { Bar = 2, Foo = "foo2" };
+                var payload = new PayloadExp { Bar = 1, Foo = "foo", Nested = nested, exp = (DateTimeOffset.UtcNow - TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
                 var result = encoder.EncodeAsUtf8Bytes(payload, null, (x, writer) => writer.Write(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(x))));
 
                 var decodeResult = decoder.TryDecode(result, x => JsonConvert.DeserializeObject<Payload>(Encoding.UTF8.GetString(x)), out var decodedPayload);
@@ -218,7 +225,8 @@ namespace LitJWT.Tests
             }
 
             {
-                var payload = new PayloadExp { Bar = 1, Foo = "foo", exp = (DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
+                var nested = new Payload { Bar = 2, Foo = "foo2" };
+                var payload = new PayloadExp { Bar = 1, Foo = "foo", Nested = nested, exp = (DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
                 var result = encoder.EncodeAsUtf8Bytes(payload, null, (x, writer) => writer.Write(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(x))));
 
                 var decodeResult = decoder.TryDecode(result, x => JsonConvert.DeserializeObject<Payload>(Encoding.UTF8.GetString(x)), out var decodedPayload);
@@ -234,7 +242,8 @@ namespace LitJWT.Tests
             var decoder = new JwtDecoder(new LitJWT.Algorithms.HS256Algorithm(key));
 
             {
-                var payload = new PayloadNbf { Bar = 1, Foo = "foo", nbf = (DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
+                var nested = new Payload { Bar = 2, Foo = "foo2" };
+                var payload = new PayloadNbf { Bar = 1, Foo = "foo", Nested = nested, nbf = (DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
                 var result = encoder.EncodeAsUtf8Bytes(payload, null, (x, writer) => writer.Write(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(x))));
 
 
@@ -243,7 +252,8 @@ namespace LitJWT.Tests
                 decodeResult.Should().Be(DecodeResult.FailedVerifyNotBefore);
             }
             {
-                var payload = new PayloadNbf { Bar = 1, Foo = "foo", nbf = (DateTimeOffset.UtcNow - TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
+                var nested = new Payload { Bar = 2, Foo = "foo2" };
+                var payload = new PayloadNbf { Bar = 1, Foo = "foo", Nested = nested, nbf = (DateTimeOffset.UtcNow - TimeSpan.FromSeconds(10)).ToUnixTimeSeconds() };
                 var result = encoder.EncodeAsUtf8Bytes(payload, null, (x, writer) => writer.Write(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(x))));
 
 


### PR DESCRIPTION
# Summary

If JWT contains nested objects, `JwtDecoder.TryDecode` method returns `Success` even if it has expired. If not contains nested objects, it returns `FailedVerifyExpire` correctly.

| returns `FailedVerifyExpire` | returns `Success` |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/4776688/192344428-2203e4ac-bb40-4a2f-9eca-b5e678a7e0f5.png) | ![image](https://user-images.githubusercontent.com/4776688/192344468-603e0dda-ce99-4cc9-8525-0a7b3a2e3c37.png) |

This problem is caused that if an `EndObject` token other than the root hierarchy is found, the while loop is broken. This PR fixes these misjudgments.
