### PR TITLE
ci: change upload-artifact & download-artifact to Cysharp/Actions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           name: nuget
           path: ./publish
+          retention-days: 1
 
   # release
   create-release:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,7 +27,7 @@ jobs:
       - run: dotnet build -c Release -p:Version=${{ inputs.tag }}
       - run: dotnet test -c Release --no-build -p:Version=${{ inputs.tag }}
       - run: dotnet pack -c Release --no-build -p:Version=${{ inputs.tag }} -o ./publish
-      - uses: actions/upload-artifact@v2
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: nuget
           path: ./publish


### PR DESCRIPTION
## tl;dr;

To handle actions/upload-artifact & download-artifact version consistency, manage actions version via Central Maanged Cysharp/Actions.
